### PR TITLE
Build with older version of Visual Studio

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,6 +50,10 @@ environment:
 platform:
     - x64
 
+# Build on this OS until we can figure out how to workaround a compiler bug
+# introduced in Update 3.
+os: Visual Studio 2015 Update 2
+
 install:
     # If there is a newer build queued for the same PR, cancel this one.
     # The AppVeyor 'rollout builds' option is supposed to serve the same


### PR DESCRIPTION
This closes #3, at least for now, by reverting to an older version of Visual Studio. 