### PR TITLE
Properly specify Numpy version dependencies.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,18 +21,22 @@ build:
     - samp_hub = astropy.samp.hub_script:hub_script
     - volint = astropy.io.votable.volint:main
     - wcslint = astropy.wcs.wcslint:main
-  number: 0
+  number: 1
 
 requirements:
 
   build:
     - python
     - setuptools
-    - numpy
+    - numpy 1.10.*  # [py27]
+    - numpy 1.10.*  # [py35]
+    - numpy 1.11.*  # [py36]
 
   run:
     - python
-    - numpy
+    - numpy >=1.10  # [py27]
+    - numpy >=1.10  # [py35]
+    - numpy >=1.11  # [py36]
     - pytest
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,14 +28,14 @@ requirements:
   build:
     - python
     - setuptools
-    - numpy 1.10.*  # [py27]
-    - numpy 1.10.*  # [py35]
+    - numpy 1.9.*  # [py27]
+    - numpy 1.9.*  # [py35]
     - numpy 1.11.*  # [py36]
 
   run:
     - python
-    - numpy >=1.10  # [py27]
-    - numpy >=1.10  # [py35]
+    - numpy >=1.9  # [py27]
+    - numpy >=1.9  # [py35]
     - numpy >=1.11  # [py36]
     - pytest
 


### PR DESCRIPTION
To maximize binary compatibility, we should *build* against as low of a version of Numpy as we can get away with, and then specify that we can *run* against any later Numpy version. What's done here is the current conda-forge standard.

Normally in conda-forge, the minimum versions are 1.7, 1.9, and 1.11 for Python 2.7, 3.5, and 3.6. But astropy requires at least numpy 1.10, so we enforce that requirement for the older Python versions.