### PR TITLE
Don't allow pytest 3.7 or later to be installed with Astropy 2.0.x

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ build:
     - samp_hub = astropy.samp.hub_script:hub_script
     - volint = astropy.io.votable.volint:main
     - wcslint = astropy.wcs.wcslint:main
-  number: 0
+  number: 1
 
 requirements:
 
@@ -37,7 +37,10 @@ requirements:
     - numpy >=1.9  # [py27]
     - numpy >=1.9  # [py35]
     - numpy >=1.11  # [py36]
-    - pytest
+
+    # Astropy 2.x is not compatible with pytest 3.8 and later
+    # https://github.com/astropy/astropy/issues/8177
+    - pytest <3.7
 
 test:
   commands:


### PR DESCRIPTION
Since Astropy 2.0.x doesn't work correctly with pytest 3.7 and later (https://github.com/astropy/astropy/issues/8177), we should ensure this is reflected in the conda recipe as a safety measure.