### PR TITLE
Don't allow pytest 4.0 or later to be installed with Astropy 3.0.x

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ build:
     - samp_hub = astropy.samp.hub_script:hub_script
     - volint = astropy.io.votable.volint:main
     - wcslint = astropy.wcs.wcslint:main
-  number: 1000
+  number: 1001
   skip: true  # [py27]
 
 requirements:
@@ -37,6 +37,11 @@ requirements:
     - numpy >=1.10  # [py35]
     - numpy >=1.11  # [py>=36]
     - pytest-astropy
+
+    # Astropy 3.0.x has compatibility issues with pytest 4.0
+    # https://github.com/astropy/astropy/pull/8170
+    # Once this recipe is updated to 3.1 we can remove this pinning
+    - pytest <4
 
 test:
   commands:


### PR DESCRIPTION
Affiliated packages using astropy 3.0.x will run into issues because [this](https://github.com/astropy/astropy/pull/8170) fix is needed for pytest 4.x compatibility, but that fix won't be in any 3.0.x release. So we should make sure that the conda build for 3.0.x specifies this incompatibility.