### PR TITLE
Allow environment to solve for Python 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About astropy
 =============
 
-Home: http://www.astropy.org/
+Home: https://www.astropy.org/
 
 Package license: BSD-3-Clause
 
@@ -11,7 +11,7 @@ Summary: Community-developed Python Library for Astronomy
 
 Development: https://github.com/astropy/astropy
 
-Documentation: http://docs.astropy.org/en/stable/
+Documentation: https://docs.astropy.org/en/stable/
 
 The Astropy Project is a community effort to develop a single package for
 Astronomy in Python. It contains core functionality and common tools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,8 +21,7 @@ build:
     - samp_hub = astropy.samp.hub_script:hub_script
     - volint = astropy.io.votable.volint:main
     - wcslint = astropy.wcs.wcslint:main
-  number: 0
-  skip: true  # [py27]
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -33,18 +32,20 @@ requirements:
     - pip
     - setuptools
     - jinja2 2.10.3
-    - cython 0.29.14
+    - cython 0.29.14  # [py<39]
+    - cython 0.29.21  # [py>=39]
     - setuptools_scm
     - extension-helpers
     - numpy 1.16.*  # [py==36]
     - numpy 1.16.*  # [py==37]
-    - numpy 1.17.*  # [py>=38]
+    - numpy 1.17.*  # [py==38]
+    - numpy 1.19.*  # [py>=39]
   run:
     - python
     - numpy >=1.16  # [py==36]
     - numpy >=1.16  # [py==37]
-    - numpy >=1.17  # [py>=38]
-
+    - numpy >=1.17  # [py==38]
+    - numpy >=1.19  # [py>=39]
 
 test:
   requires:
@@ -62,7 +63,7 @@ test:
     - astropy
 
 about:
-  home: http://www.astropy.org/
+  home: https://www.astropy.org/
   license: BSD-3-Clause
   license_file: LICENSE.rst
   summary: Community-developed Python Library for Astronomy
@@ -70,7 +71,7 @@ about:
     The Astropy Project is a community effort to develop a single package for
     Astronomy in Python. It contains core functionality and common tools
     needed for performing astronomy and astrophysics research with Python.
-  doc_url: http://docs.astropy.org/en/stable/
+  doc_url: https://docs.astropy.org/en/stable/
   dev_url: https://github.com/astropy/astropy
 
 extra:


### PR DESCRIPTION
Currently the Python 3.9 migration is held up because this environment cannot be solved for Python 3.9.
This PR adds the minimum versions of cython and numpy that are available with Python 3.9 builds on conda-forge.
The resulting Python 3.6-3.8 builds should be identical to the existing ones.

The PR does **not** enable a Python 3.9 build on the feedstock itself, on merging it should enable the bot to open a migration PR, which can then be used to figure out whether the build works or not.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
