### PR TITLE
Do not require scipy for astropy-base, only astropy

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,12 +45,11 @@ requirements:
     - numpy
   run:
     - python
-    - numpy >=1.23
+    - numpy >=1.23.2
     - pyerfa >=2.0.1.1
     - astropy-iers-data >=0.2024.10.28.0.34.7
-    - importlib-metadata
-    - pyyaml >=3.13
-    - packaging >=19.0
+    - pyyaml >=6.0.0
+    - packaging >=29.0.0
   run_constrained:
     # We must prevent installing old astropy and new astropy-base together
     - astropy >=7.0.0
@@ -101,26 +100,26 @@ outputs:
       run:
         - python >={{ python_min }}
         - {{ pin_subpackage('astropy-base', max_pin="x.x.x") }}
-        - matplotlib-base >=3.5.0,!=3.5.2
-        - certifi
+        - matplotlib-base >=3.6.0,!=3.5.2
         - scipy >=1.9.2
+        - certifi >=2022.6.15.1
         # We also need numpy from dask[array] but we are already going to install that.
-        - dask-core >=2022.8.1
-        - h5py
+        - dask-core >=2022.5.1
+        - h5py >=3.8.0
         - pyarrow >=10.0.1
-        - beautifulsoup4
-        - html5lib
-        - bleach
+        - beautifulsoup4 >=4.9.3
+        - html5lib >=1.1
+        - bleach >=3.2.1
         - pandas >=2.0
-        - sortedcontainers
-        - pytz
-        - jplephem
-        - mpmath
-        - bottleneck
+        - sortedcontainers >=1.5.7
+        - pytz >=2016.10
+        - jplephem >=2.6
+        - mpmath >=1.2.1
+        - bottleneck >=1.3.3
         - fsspec >=2023.4.0
         # fsspec optional deps
         - aiohttp
-        - s3fs
+        - s3fs >=2023.4.0
     test:
       requires:
         - python {{ python_min }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,6 @@ requirements:
     - importlib-metadata
     - pyyaml >=3.13
     - packaging >=19.0
-    - scipy >=1.8
   run_constrained:
     # We must prevent installing old astropy and new astropy-base together
     - astropy >=7.0.0
@@ -104,6 +103,7 @@ outputs:
         - {{ pin_subpackage('astropy-base', max_pin="x.x.x") }}
         - matplotlib-base >=3.5.0,!=3.5.2
         - certifi
+        - scipy >=1.9.2
         # We also need numpy from dask[array] but we are already going to install that.
         - dask-core >=2022.8.1
         - h5py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,7 @@ requirements:
     - pyerfa >=2.0.1.1
     - astropy-iers-data >=0.2024.10.28.0.34.7
     - pyyaml >=6.0.0
-    - packaging >=29.0.0
+    - packaging >=22.0.0
   run_constrained:
     # We must prevent installing old astropy and new astropy-base together
     - astropy >=7.0.0
@@ -100,7 +100,7 @@ outputs:
       run:
         - python >={{ python_min }}
         - {{ pin_subpackage('astropy-base', max_pin="x.x.x") }}
-        - matplotlib-base >=3.6.0,!=3.5.2
+        - matplotlib-base >=3.6.0
         - scipy >=1.9.2
         - certifi >=2022.6.15.1
         # We also need numpy from dask[array] but we are already going to install that.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: e92d7c9fee86eb3df8714e5dd41bbf9f163d343e1a183d95bf6bd09e4313c940
 
 build:
-  number: 1
+  number: 2
   {% if py < min_py %}
   skip: true
   {% endif %}


### PR DESCRIPTION
I noticed that past me (for some reason) had scipy as a requirement on astropy-base not astropy, which feels wrong?

Also I noticed that I hadn't copied all the lastest version mins from pyproject.toml, so this also bumps that (in the second commit).

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
